### PR TITLE
One of position fix

### DIFF
--- a/lib/exprotobuf/define_message.ex
+++ b/lib/exprotobuf/define_message.ex
@@ -104,17 +104,20 @@ defmodule Protobuf.DefineMessage do
   end
 
   defp record_fields(fields) do
-    for %Field{name: name, occurrence: occurrence} <- fields do
-      {name, case occurrence do
-        :repeated -> []
-        _ -> nil
-      end}
-    end
-    ++
-    for %OneOfField{name: name} <- fields do
-      {name, nil}
-    end
-
+    fields
+    |> Enum.map(fn(field) ->
+      case field do
+        %Field{name: name, occurrence: :repeated} ->
+          {name, []}
+        %Field{name: name} ->
+          {name, nil}
+        %OneOfField{name: name} ->
+          {name, nil}
+        _ ->
+          nil
+      end
+    end)
+    |> Enum.reject(fn(field) -> is_nil(field) end)
   end
 
 end

--- a/test/proto/one_of.proto
+++ b/test/proto/one_of.proto
@@ -19,3 +19,12 @@ message AdvancedOneofMsg {
     uint32 code = 4;
   }
 }
+
+message ReversedOrderOneOfMsg {
+	oneof foo {
+		string body = 1;
+		uint32 code = 2;
+	}
+
+	optional string bar = 3;
+}

--- a/test/protobuf/one_of_test.exs
+++ b/test/protobuf/one_of_test.exs
@@ -66,4 +66,12 @@ defmodule Protobuf.Oneof.Test do
     assert is_binary(enc_msg)
   end
 
+  test "can decode one_of protos with one_of field on first position" do
+    enc_msg= <<16, 32, 26, 2, 104, 105>>
+    dec_msg = Msgs.ReversedOrderOneOfMsg.decode(enc_msg)
+
+    assert Msgs.ReversedOrderOneOfMsg.new(foo: {:code, 32}, bar: "hi") == dec_msg
+  end
+
+
 end

--- a/test/protobuf/one_of_test.exs
+++ b/test/protobuf/one_of_test.exs
@@ -59,4 +59,11 @@ defmodule Protobuf.Oneof.Test do
     assert %Msgs.AdvancedOneofMsg{foo: {:body,  Msgs.SubMsg.new(test: "yyy")}, one: Msgs.SubMsg.new(test: "xxx")} == msg
   end
 
+  test "can encode one_of protos with one_of field on first position" do
+    msg = Msgs.ReversedOrderOneOfMsg.new(foo: {:code, 32}, bar: "hi")
+    enc_msg = Msgs.ReversedOrderOneOfMsg.encode(msg)
+
+    assert is_binary(enc_msg)
+  end
+
 end


### PR DESCRIPTION
Fixed issue when proto messages with one_of not on last position could not be properly encoded due to invalid position in record.
